### PR TITLE
[clang][docs] Improve "Obtainig Clang" section

### DIFF
--- a/clang/docs/LibASTMatchersTutorial.rst
+++ b/clang/docs/LibASTMatchersTutorial.rst
@@ -22,8 +22,8 @@ started guide <https://llvm.org/docs/GettingStarted.html>`_.
 
 .. code-block:: console
 
-      cd ~/clang-llvm
-      git clone https://github.com/llvm/llvm-project.git
+      mkdir ~/clang-llvm && cd ~/clang-llvm
+      git clone https://github.com/llvm/llvm-project.git .
 
 Next you need to obtain the CMake build system and Ninja build tool.
 


### PR DESCRIPTION
The documentation is written relatively to `clang-llvm`, not the root repository directory. Therefore, the `llvm-project` repo needs to be cloned into the existing directory `clang-llvm`. As cloning into an existing directory is only allowed if the directory is empty, I added `mkdir ~/clang-llvm` to make the intent of creating an empty directory explicit.